### PR TITLE
Fix composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-dev --no-interaction --prefer-source
 
 language: php
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install:
-  - travis_retry composer install --no-dev --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction --prefer-source
 
 language: php
 php:

--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,9 @@
             "php artisan optimize"
         ],
         "pre-update-cmd": [
-            "php artisan clear-compiled"
         ],
         "post-update-cmd": [
+            "php artisan clear-compiled",
             "php artisan optimize"
         ]
     },


### PR DESCRIPTION
Fix composer install when something happens to the vendor directory and composer thinks it is installed already, the pre-update command will fail.
