### PR TITLE
Necessary change for postgresql compliance

### DIFF
--- a/database/migrations/2016_01_27_204653_create_users_widgets_table.php
+++ b/database/migrations/2016_01_27_204653_create_users_widgets_table.php
@@ -22,7 +22,7 @@ class CreateUsersWidgetsTable extends Migration
             $table->boolean('size_x');
             $table->boolean('size_y');
             $table->string('title');
-            $table->boolean('refresh')->default(60);
+            $table->integer('refresh')->default(60);
             $table->text('settings', 65535);
             $table->integer('dashboard_id');
             $table->index(['user_id', 'widget_id']);


### PR DESCRIPTION
We can't set a numeric/string value for a boolean field on postgresql, hence I've made a small change in the migration file. 
