### PR TITLE
Use transactions for database tests to speed up tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 
+php:
+  - 5.6
+  - 7.0
+  - hhvm
+
 matrix:
   fast_finish: true
-  include:
-  - php: 5.6
-  - php: 7.0
-  - php: hhvm
-
-
   allow_failures:
   - php: hhvm
 
@@ -25,7 +24,7 @@ cache:
 before_install:
   # Disable xdebug (hhvm doesn't support xdebug)
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
-  - mysql -e 'CREATE DATABASE IF NOT EXISTS phpunit_librenms;'
+  - mysql -e 'CREATE DATABASE phpunit_librenms;'
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
   allow_failures:
   - php: hhvm
 
+services:
+  - mysql
+
+env:
+  - PHPUNIT_DB_CONNECTION=testing_mysql
+
 cache:
   directories:
     - vendor
@@ -19,6 +25,7 @@ cache:
 before_install:
   # Disable xdebug (hhvm doesn't support xdebug)
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS phpunit_librenms;'
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist

--- a/config/database.php
+++ b/config/database.php
@@ -26,7 +26,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'mysql'),
+    'default' => env('APP_ENV') == 'testing' ? env('PHPUNIT_DB_CONNECTION', 'testing_sqlite') : env('DB_CONNECTION', 'mysql'),
 
     /*
     |--------------------------------------------------------------------------

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,7 +20,6 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
-        <env name="DB_CONNECTION" value="testing_sqlite"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/tests/DatabaseSetup.php
+++ b/tests/DatabaseSetup.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * DatabaseSetup.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package    LibreNMS
+ * @link       http://librenms.org
+ * @copyright  2016 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait DatabaseSetup
+{
+    protected static $migrated = false;
+
+    public function setupDatabase()
+    {
+        if ($this->isInMemory()) {
+            $this->setupInMemoryDatabase();
+        } else {
+            $this->setupTestDatabase();
+        }
+    }
+
+    protected function isInMemory()
+    {
+        return config('database.connections')[config('database.default')]['database'] == ':memory:';
+    }
+
+    protected function setupInMemoryDatabase()
+    {
+        $this->artisan('migrate');
+        $this->app[Kernel::class]->setArtisan(null);
+    }
+
+    protected function setupTestDatabase()
+    {
+        if (!static::$migrated) {
+            $this->artisan('migrate:refresh');
+            $this->app[Kernel::class]->setArtisan(null);
+            static::$migrated = true;
+        }
+        $this->beginDatabaseTransaction();
+    }
+
+    public function beginDatabaseTransaction()
+    {
+        $database = $this->app->make('db');
+        foreach ($this->connectionsToTransact() as $name) {
+            $database->connection($name)->beginTransaction();
+        }
+        $this->beforeApplicationDestroyed(function () use ($database) {
+            foreach ($this->connectionsToTransact() as $name) {
+                $database->connection($name)->rollBack();
+            }
+        });
+    }
+
+    protected function connectionsToTransact()
+    {
+        return property_exists($this, 'connectionsToTransact')
+            ? $this->connectionsToTransact : [null];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,12 +1,10 @@
 <?php
 namespace Tests;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-
 class TestCase extends \Illuminate\Foundation\Testing\TestCase
 {
-    // This will migrate and rollback the database for each test
-    use DatabaseMigrations;
+    // This will migrate and rollback the database for each test, or use transactions with a db, automatically migrating
+    use DatabaseSetup;
 
     /**
      * The base URL to use while testing the application.
@@ -14,6 +12,12 @@ class TestCase extends \Illuminate\Foundation\Testing\TestCase
      * @var string
      */
     protected $baseUrl = 'http://localhost:12345';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->setupDatabase();
+    }
 
     /**
      * Creates the application.

--- a/tests/webui/commands/UserAddTest.php
+++ b/tests/webui/commands/UserAddTest.php
@@ -102,7 +102,7 @@ class UserAddTest extends TestCase
         // call the handle function
         $mock->handle();
 
-        $user = User::find(1)->first();
+        $user = User::first();
         $this->assertEquals($username, $user->username);
         $this->assertEquals($realname, $user->realname);
         $this->assertEquals($email, $user->email);


### PR DESCRIPTION
Please see our [contributing docs](https://github.com/librenms/librenmsv2/blob/develop/docs/General/Contributing.md)

- [x] Have you created any necessary docs?
- [x] Have you created tests for Travis integration?
- [x] Have you used localisation in the WebUI?
- [x] Have you included the proper copyright?

Default to sqlite in-memory with migrations unless  PHPUNIT_DB_CONNECTION=testing_mysql is set in .env